### PR TITLE
Fixed logging and messageKey field added to the PasswordValidationException.

### DIFF
--- a/service/src/main/java/com/epam/rft/atsy/service/exception/PasswordValidationException.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/exception/PasswordValidationException.java
@@ -1,22 +1,19 @@
 package com.epam.rft.atsy.service.exception;
 
-import java.util.ResourceBundle;
-
 public class PasswordValidationException extends Exception {
     private String messageKey;
 
-    public PasswordValidationException() {
-    }
-
     public PasswordValidationException(String messageKey) {
-        // Both getMessage() and getMessageKey() will return the message key.
-        // getMessageKey() should be used when it helps understanding by its semantics.
-        super(messageKey);
-
         this.messageKey = messageKey;
     }
 
     public String getMessageKey() {
         return messageKey;
     }
+
+    @Override
+    public String getMessage() {
+        return "Password validation failed. The message key: " + messageKey;
+    }
+
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/exception/PasswordValidationException.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/exception/PasswordValidationException.java
@@ -1,11 +1,22 @@
 package com.epam.rft.atsy.service.exception;
 
+import java.util.ResourceBundle;
+
 public class PasswordValidationException extends Exception {
+    private String messageKey;
 
     public PasswordValidationException() {
     }
 
-    public PasswordValidationException(String message) {
-        super(message);
+    public PasswordValidationException(String messageKey) {
+        // Both getMessage() and getMessageKey() will return the message key.
+        // getMessageKey() should be used when it helps understanding by its semantics.
+        super(messageKey);
+
+        this.messageKey = messageKey;
+    }
+
+    public String getMessageKey() {
+        return messageKey;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/PasswordValidationRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/PasswordValidationRule.java
@@ -5,5 +5,11 @@ import com.epam.rft.atsy.service.domain.PasswordChangeDTO;
 public interface PasswordValidationRule {
 
     boolean isValid(PasswordChangeDTO passwordChangeDTO);
-    String getErrorMessage();
+
+    /**
+     *  Gets the message key that corresponds to the rule violation.
+     *
+     *  @return the corresponding message key
+     */
+    String getErrorMessageKey();
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordAllFieldFilledRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordAllFieldFilledRule.java
@@ -5,18 +5,22 @@ import com.epam.rft.atsy.service.passwordchange.validation.PasswordValidationRul
 import org.apache.commons.lang3.StringUtils;
 
 public class PasswordAllFieldFilledRule implements PasswordValidationRule {
-
-    public static final String MESSAGE_KEY="passwordchange.validation.allfieldfilled";
+    private static final String MESSAGE_KEY = "passwordchange.validation.allfieldfilled";
 
     @Override
     public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
-        return StringUtils.isNotBlank(passwordChangeDTO.getNewPassword()) &&
-                StringUtils.isNotBlank(passwordChangeDTO.getNewPasswordConfirm()) &&
-                StringUtils.isNotBlank(passwordChangeDTO.getOldPassword());
+        String newPassword = passwordChangeDTO.getNewPassword();
+
+        return StringUtils.isNotBlank(newPassword) &&
+                StringUtils.isNotBlank(newPassword) &&
+                StringUtils.isNotBlank(newPassword);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public String getErrorMessage() {
+    public String getErrorMessageKey() {
         return MESSAGE_KEY;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordAllFieldFilledRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordAllFieldFilledRule.java
@@ -16,9 +16,6 @@ public class PasswordAllFieldFilledRule implements PasswordValidationRule {
                 StringUtils.isNotBlank(newPassword);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getErrorMessageKey() {
         return MESSAGE_KEY;

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordContainsRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordContainsRule.java
@@ -27,9 +27,6 @@ public class PasswordContainsRule implements PasswordValidationRule {
         return password.matches(".*[!@#$%^&_.,;:-]+.*");
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getErrorMessageKey() {
         return MESSAGE_KEY;

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordContainsRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordContainsRule.java
@@ -4,14 +4,15 @@ import com.epam.rft.atsy.service.domain.PasswordChangeDTO;
 import com.epam.rft.atsy.service.passwordchange.validation.PasswordValidationRule;
 
 public class PasswordContainsRule implements PasswordValidationRule {
-
-    public static final String MESSAGE_KEY="passwordchange.validation.contains";
+    private static final String MESSAGE_KEY = "passwordchange.validation.contains";
 
     @Override
     public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
-        return containsLetters(passwordChangeDTO.getNewPassword()) &&
-                containsNumbers(passwordChangeDTO.getNewPassword()) &&
-                containsSpecial(passwordChangeDTO.getNewPassword());
+        String newPassword = passwordChangeDTO.getNewPassword();
+
+        return containsLetters(newPassword) &&
+                containsNumbers(newPassword) &&
+                containsSpecial(newPassword);
     }
 
     private boolean containsLetters(String password){
@@ -26,8 +27,11 @@ public class PasswordContainsRule implements PasswordValidationRule {
         return password.matches(".*[!@#$%^&_.,;:-]+.*");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public String getErrorMessage() {
+    public String getErrorMessageKey() {
         return MESSAGE_KEY;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordLengthValidationRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordLengthValidationRule.java
@@ -12,9 +12,6 @@ public class PasswordLengthValidationRule implements PasswordValidationRule {
         return passwordChangeDTO.getNewPassword().length() >= PASSWORD_MIN_LENGTH;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getErrorMessageKey() {
         return MESSAGE_KEY;

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordLengthValidationRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordLengthValidationRule.java
@@ -4,17 +4,19 @@ import com.epam.rft.atsy.service.domain.PasswordChangeDTO;
 import com.epam.rft.atsy.service.passwordchange.validation.PasswordValidationRule;
 
 public class PasswordLengthValidationRule implements PasswordValidationRule {
-
-    public static final int PASSWORD_MIN_LENGTH = 6;
-    public static final String MESSAGE_KEY="passwordchange.validation.length";
+    private static final int PASSWORD_MIN_LENGTH = 6;
+    private static final String MESSAGE_KEY = "passwordchange.validation.length";
 
     @Override
     public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
-        return passwordChangeDTO.getNewPassword().length()>= PASSWORD_MIN_LENGTH;
+        return passwordChangeDTO.getNewPassword().length() >= PASSWORD_MIN_LENGTH;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public String getErrorMessage() {
+    public String getErrorMessageKey() {
         return MESSAGE_KEY;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordNewMatchValidationRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordNewMatchValidationRule.java
@@ -11,9 +11,6 @@ public class PasswordNewMatchValidationRule implements PasswordValidationRule {
         return passwordChangeDTO.getNewPassword().equals(passwordChangeDTO.getNewPasswordConfirm());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getErrorMessageKey() {
         return MESSAGE_KEY;

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordNewMatchValidationRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordNewMatchValidationRule.java
@@ -4,16 +4,18 @@ import com.epam.rft.atsy.service.domain.PasswordChangeDTO;
 import com.epam.rft.atsy.service.passwordchange.validation.PasswordValidationRule;
 
 public class PasswordNewMatchValidationRule implements PasswordValidationRule {
-
-    public static final String MESSAGE_KEY="passwordchange.validation.newpasswordmatch";
+    private static final String MESSAGE_KEY = "passwordchange.validation.newpasswordmatch";
 
     @Override
     public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
         return passwordChangeDTO.getNewPassword().equals(passwordChangeDTO.getNewPasswordConfirm());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public String getErrorMessage() {
+    public String getErrorMessageKey() {
         return MESSAGE_KEY;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordOldPasswordMatchesRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordOldPasswordMatchesRule.java
@@ -8,17 +8,27 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 public class PasswordOldPasswordMatchesRule implements PasswordValidationRule {
 
-    public static final String MESSAGE_KEY="passwordchange.validation.oldpasswordmatch";
+    private static final String MESSAGE_KEY = "passwordchange.validation.oldpasswordmatch";
 
-    @Override
-    public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
-        UserDetails userDetails = (UserDetails)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
-        return bCryptPasswordEncoder.matches(passwordChangeDTO.getOldPassword(), userDetails.getPassword());
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public PasswordOldPasswordMatchesRule() {
+        bCryptPasswordEncoder = new BCryptPasswordEncoder();
     }
 
     @Override
-    public String getErrorMessage() {
+    public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
+        UserDetails userDetails =
+                (UserDetails)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        return bCryptPasswordEncoder.matches(passwordChangeDTO.getOldPassword(), userDetails.getPassword());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getErrorMessageKey() {
         return MESSAGE_KEY;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordOldPasswordMatchesRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordOldPasswordMatchesRule.java
@@ -24,9 +24,6 @@ public class PasswordOldPasswordMatchesRule implements PasswordValidationRule {
         return bCryptPasswordEncoder.matches(passwordChangeDTO.getOldPassword(), userDetails.getPassword());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getErrorMessageKey() {
         return MESSAGE_KEY;

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordUniqueRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordUniqueRule.java
@@ -40,9 +40,6 @@ public class PasswordUniqueRule implements PasswordValidationRule {
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getErrorMessageKey() {
         return MESSAGE_KEY;

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordUniqueRule.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordUniqueRule.java
@@ -13,28 +13,38 @@ import java.util.List;
 
 @Component
 public class PasswordUniqueRule implements PasswordValidationRule {
+    private static final String MESSAGE_KEY = "passwordchange.validation.unique";
 
     @Resource
     private PasswordChangeService passwordChangeService;
 
-    BCryptPasswordEncoder bCryptPasswordEncoder = new BCryptPasswordEncoder();
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    public static final String MESSAGE_KEY="passwordchange.validation.unique";
-
-    @Override
-    public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        List<String> oldPasswords = passwordChangeService.getOldPasswords(((UserDetailsAdapter)principal).getUserId());
-        for(String pass:oldPasswords){
-            if(bCryptPasswordEncoder.matches(passwordChangeDTO.getNewPassword(),pass)){
-                return false;
-            }
-        }
-        return true;
+    public PasswordUniqueRule() {
+        bCryptPasswordEncoder = new BCryptPasswordEncoder();
     }
 
     @Override
-    public String getErrorMessage() {
+    public boolean isValid(PasswordChangeDTO passwordChangeDTO) {
+        UserDetailsAdapter userDetails =
+                (UserDetailsAdapter)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        List<String> oldPasswords = passwordChangeService.getOldPasswords(userDetails.getUserId());
+
+        for (String password : oldPasswords) {
+            if (bCryptPasswordEncoder.matches(passwordChangeDTO.getNewPassword(), password)){
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getErrorMessageKey() {
         return MESSAGE_KEY;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordValidatorImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordValidatorImpl.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 @Component
 public class PasswordValidatorImpl implements PasswordValidator {
-
     private final List<PasswordValidationRule> passwordValidationRules;
 
     @Autowired
@@ -31,11 +30,13 @@ public class PasswordValidatorImpl implements PasswordValidator {
     @Override
     public boolean validate(PasswordChangeDTO passwordChangeDTO) throws PasswordValidationException {
         for (PasswordValidationRule passwordValidationRule : passwordValidationRules) {
-            if(!passwordValidationRule.isValid(passwordChangeDTO)) {
-                throw new PasswordValidationException(passwordValidationRule.getErrorMessage());
+            if (!passwordValidationRule.isValid(passwordChangeDTO)) {
+                throw new PasswordValidationException(passwordValidationRule.getErrorMessageKey());
             }
         }
 
+        // Is this really necessary? At this point all rules have been satisfied therefore
+        // the method might be void instead of returning such a non-informative value.
         return true;
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordValidatorImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/passwordchange/validation/impl/PasswordValidatorImpl.java
@@ -35,8 +35,6 @@ public class PasswordValidatorImpl implements PasswordValidator {
             }
         }
 
-        // Is this really necessary? At this point all rules have been satisfied therefore
-        // the method might be void instead of returning such a non-informative value.
         return true;
     }
 }

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/PasswordChangeController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/PasswordChangeController.java
@@ -76,8 +76,9 @@ public class PasswordChangeController {
                 userDetailsAdapter.setPassword(newPassword);
                 model.addObject(VALIDATION_SUCCESS_KEY, PASSWORDCHANGE_VALIDATION_SUCCESS);
             } catch (PasswordValidationException e) {
-                logger.error(e.getMessage());
-                model.addObject(VALIDATION_ERROR_KEY,e.getMessage());
+                logger.error(e.getMessage(), e);
+
+                model.addObject(VALIDATION_ERROR_KEY, e.getMessageKey());
             }
         }
         return model;


### PR DESCRIPTION
This pull request was dependent on the
epam-debrecen-rft-2015/atsy#12
pull request.

Trello card
[https://trello.com/c/vtH3dKXJ](https://trello.com/c/vtH3dKXJ)

Additionally to the task, I've made some changes in the `PasswordXXRule` classes. Mostly stylistic issues were fixed to help the readability but I also replaced the `public` modifiers of the `MESSAGE_KEY` constants with `private`.

The `PasswordValidationRule.getErrorMessage()` method was renamed based on the fact that it doesn't actually return an error message just a message key.
