### PR TITLE
DuplicateRecordException rewritten and extended, logging introduced for DRE.

### DIFF
--- a/service/src/main/java/com/epam/rft/atsy/service/exception/DuplicateRecordException.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/exception/DuplicateRecordException.java
@@ -1,7 +1,7 @@
 package com.epam.rft.atsy.service.exception;
 
 public class DuplicateRecordException extends RuntimeException {
-    private  final String name;
+    private final String name;
 
     public DuplicateRecordException(String name, String message, Throwable cause) {
         super(message, cause);

--- a/service/src/main/java/com/epam/rft/atsy/service/exception/DuplicateRecordException.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/exception/DuplicateRecordException.java
@@ -1,9 +1,11 @@
 package com.epam.rft.atsy.service.exception;
 
 public class DuplicateRecordException extends RuntimeException {
-    private final String name;
+    private  final String name;
 
-    public DuplicateRecordException(String name) {
+    public DuplicateRecordException(String name, String message, Throwable cause) {
+        super(message, cause);
+
         this.name = name;
     }
 

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/CandidateServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/CandidateServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Resource;
 import java.lang.reflect.Type;
@@ -22,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Service
+@Slf4j
 public class CandidateServiceImpl implements CandidateService {
 
     @Resource
@@ -53,8 +55,13 @@ public class CandidateServiceImpl implements CandidateService {
         CandidateEntity entity = modelMapper.map(candidate, CandidateEntity.class);
         try {
             return candidateRepository.save(entity).getId();
-        } catch (ConstraintViolationException | DataIntegrityViolationException constraint) {
-            throw new DuplicateRecordException(candidate.getName());
+        } catch (ConstraintViolationException | DataIntegrityViolationException ex) {
+            log.error("Save to repository failed.", ex);
+
+            String candidateName = candidate.getName();
+
+            throw new DuplicateRecordException(candidateName,
+                                               "Duplication occurred when saving candidate: " + candidateName, ex);
         }
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/ChannelServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/ChannelServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Resource;
 import java.lang.reflect.Type;
@@ -19,6 +20,7 @@ import java.util.Collection;
 import java.util.List;
 
 @Service
+@Slf4j
 public class ChannelServiceImpl implements ChannelService {
 
     @Resource
@@ -41,8 +43,13 @@ public class ChannelServiceImpl implements ChannelService {
         ChannelEntity entity = modelMapper.map(channel, ChannelEntity.class);
         try {
             channelRepository.save(entity);
-        } catch (ConstraintViolationException | DataIntegrityViolationException constraint) {
-            throw new DuplicateRecordException(channel.getName());
+        } catch (ConstraintViolationException | DataIntegrityViolationException ex) {
+            log.error("Save to repository failed.", ex);
+
+            String channelName = channel.getName();
+
+            throw new DuplicateRecordException(channelName,
+                                               "Duplication occurred when saving channel: " + channelName, ex);
         }
     }
 }

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/PasswordChangeServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/PasswordChangeServiceImpl.java
@@ -46,10 +46,11 @@ public class PasswordChangeServiceImpl implements PasswordChangeService {
         } catch (ConstraintViolationException | DataIntegrityViolationException ex) {
             log.error("Save to repository failed.", ex);
 
-            String historyId = passwordHistoryDTO.getId().toString();
+            String userId = passwordHistoryDTO.getUserId().toString();
 
-            throw new DuplicateRecordException(historyId, "Duplication occurred when saving password history with ID: "
-                                               + historyId, ex);
+            throw new DuplicateRecordException(userId,
+                                               "Duplication occurred when saving password history for user with ID: "
+                                               + userId, ex);
         }
     }
 

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/PasswordChangeServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/PasswordChangeServiceImpl.java
@@ -12,12 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 public class PasswordChangeServiceImpl implements PasswordChangeService {
 
     @Resource
@@ -41,8 +43,13 @@ public class PasswordChangeServiceImpl implements PasswordChangeService {
                 deleteOldestPassword(passwordHistoryDTO.getUserId());
             }
             return retId;
-        } catch (ConstraintViolationException | DataIntegrityViolationException constraint) {
-            throw new DuplicateRecordException(passwordHistoryDTO.getId().toString());
+        } catch (ConstraintViolationException | DataIntegrityViolationException ex) {
+            log.error("Save to repository failed.", ex);
+
+            String historyId = passwordHistoryDTO.getId().toString();
+
+            throw new DuplicateRecordException(historyId, "Duplication occurred when saving password history with ID: "
+                                               + historyId, ex);
         }
     }
 

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/PositionServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/PositionServiceImpl.java
@@ -12,12 +12,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Resource;
 import java.util.Collection;
 import java.util.List;
 
 @Service
+@Slf4j
 public class PositionServiceImpl implements PositionService {
 
     @Resource
@@ -38,8 +40,13 @@ public class PositionServiceImpl implements PositionService {
         PositionEntity entity = modelMapper.map(position, PositionEntity.class);
         try {
             positionRepository.save(entity);
-        } catch (ConstraintViolationException | DataIntegrityViolationException constraint) {
-            throw new DuplicateRecordException(position.getName());
+        } catch (ConstraintViolationException | DataIntegrityViolationException ex) {
+            log.error("Save to repository failed.", ex);
+
+            String positionName = position.getName();
+
+            throw new DuplicateRecordException(positionName,
+                                               "Duplication occurred when saving position: " + positionName, ex);
         }
     }
 

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/UserServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/UserServiceImpl.java
@@ -16,12 +16,14 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Resource;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
 
 @Service
+@Slf4j
 public class UserServiceImpl implements UserService {
 
     private static final Logger LOGGER= LoggerFactory.getLogger(UserServiceImpl.class);
@@ -54,8 +56,13 @@ public class UserServiceImpl implements UserService {
         UserEntity entity = modelMapper.map(userDTO, UserEntity.class);
         try {
             return userRepository.save(entity).getId();
-        } catch (ConstraintViolationException | DataIntegrityViolationException constraint) {
-            throw new DuplicateRecordException("User already exists!");
+        } catch (ConstraintViolationException | DataIntegrityViolationException ex) {
+            log.error("Save to repository failed.", ex);
+
+            String userName = entity.getUserName();
+
+            throw new DuplicateRecordException(userName,
+                                               "Duplication occurred when saving user: " + userName, ex);
         }
     }
 

--- a/service/src/main/java/com/epam/rft/atsy/service/impl/UserServiceImpl.java
+++ b/service/src/main/java/com/epam/rft/atsy/service/impl/UserServiceImpl.java
@@ -25,9 +25,6 @@ import javax.persistence.NonUniqueResultException;
 @Service
 @Slf4j
 public class UserServiceImpl implements UserService {
-
-    private static final Logger LOGGER= LoggerFactory.getLogger(UserServiceImpl.class);
-
     @Autowired
     private UserRepository userRepository;
     @Resource
@@ -42,7 +39,7 @@ public class UserServiceImpl implements UserService {
         } catch (NoResultException | EmptyResultDataAccessException | NonUniqueResultException e) {
             throw new UserNotFoundException(e);
         }catch (Exception e){
-            LOGGER.error("User failed to login",e);
+            log.error("User failed to login",e);
             throw new BackendException(e);
         }
 


### PR DESCRIPTION
Trello card:
[https://trello.com/c/S26OTWkj](https://trello.com/c/S26OTWkj)

The `name` field of the `DuplicateRecordException` is preserved to store the name of the object that caused the duplication but a `message` field has been added to provide useful error messages in the log output.
