### PR TITLE
Set the content type (including the charset) in REST controller exception handlers.

### DIFF
--- a/web/src/main/java/com/epam/rft/atsy/web/MediaTypes.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/MediaTypes.java
@@ -1,0 +1,14 @@
+package com.epam.rft.atsy.web;
+
+import org.springframework.http.MediaType;
+
+import java.nio.charset.Charset;
+
+public class MediaTypes {
+    public static final MediaType TEXT_PLAIN_UTF8 =
+            new MediaType("text", "plain", Charset.forName("UTF-8"));
+
+    private MediaTypes() {
+        // Private to prevent instantiating.
+    }
+}

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/ChannelController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/ChannelController.java
@@ -7,12 +7,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -23,6 +26,10 @@ public class ChannelController {
     private static final String EMPTY_POSITION_NAME_MESSAGE_KEY = "settings.channels.error.empty";
     private static final String TECHNICAL_ERROR_MESSAGE_KEY = "technical.error.message";
     private static final Logger LOGGER = LoggerFactory.getLogger(ChannelController.class);
+
+    private static final MediaType TEXT_PLAIN_UTF8 =
+            new MediaType("text", "plain", Charset.forName("UTF-8"));
+
     @Resource
     private ChannelService channelService;
     @Resource
@@ -48,15 +55,24 @@ public class ChannelController {
 
     @ExceptionHandler(DuplicateRecordException.class)
     public ResponseEntity handleDuplicateException(Locale locale, DuplicateRecordException ex) {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(TEXT_PLAIN_UTF8);
+
         return new ResponseEntity<>(messageSource.getMessage(DUPLICATE_POSITION_MESSAGE_KEY,
-                new Object[]{ex.getName()}, locale), HttpStatus.BAD_REQUEST);
+                new Object[]{ex.getName()}, locale), headers, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity handleException(Locale locale, Exception ex) {
         LOGGER.error("Error while saving channel changes", ex);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(TEXT_PLAIN_UTF8);
+
         return new ResponseEntity<>(messageSource.getMessage(TECHNICAL_ERROR_MESSAGE_KEY,
-                null, locale), HttpStatus.BAD_REQUEST);
+                null, locale), headers, HttpStatus.BAD_REQUEST);
     }
 
 

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/ChannelController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/ChannelController.java
@@ -3,6 +3,7 @@ package com.epam.rft.atsy.web.controllers.rest;
 import com.epam.rft.atsy.service.ChannelService;
 import com.epam.rft.atsy.service.domain.ChannelDTO;
 import com.epam.rft.atsy.service.exception.DuplicateRecordException;
+import com.epam.rft.atsy.web.MediaTypes;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,9 +27,6 @@ public class ChannelController {
     private static final String EMPTY_POSITION_NAME_MESSAGE_KEY = "settings.channels.error.empty";
     private static final String TECHNICAL_ERROR_MESSAGE_KEY = "technical.error.message";
     private static final Logger LOGGER = LoggerFactory.getLogger(ChannelController.class);
-
-    private static final MediaType TEXT_PLAIN_UTF8 =
-            new MediaType("text", "plain", Charset.forName("UTF-8"));
 
     @Resource
     private ChannelService channelService;
@@ -57,7 +55,7 @@ public class ChannelController {
     public ResponseEntity handleDuplicateException(Locale locale, DuplicateRecordException ex) {
         HttpHeaders headers = new HttpHeaders();
 
-        headers.setContentType(TEXT_PLAIN_UTF8);
+        headers.setContentType(MediaTypes.TEXT_PLAIN_UTF8);
 
         return new ResponseEntity<>(messageSource.getMessage(DUPLICATE_POSITION_MESSAGE_KEY,
                 new Object[]{ex.getName()}, locale), headers, HttpStatus.BAD_REQUEST);
@@ -69,7 +67,7 @@ public class ChannelController {
 
         HttpHeaders headers = new HttpHeaders();
 
-        headers.setContentType(TEXT_PLAIN_UTF8);
+        headers.setContentType(MediaTypes.TEXT_PLAIN_UTF8);
 
         return new ResponseEntity<>(messageSource.getMessage(TECHNICAL_ERROR_MESSAGE_KEY,
                 null, locale), headers, HttpStatus.BAD_REQUEST);

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/PositionController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/PositionController.java
@@ -7,12 +7,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -23,6 +26,10 @@ public class PositionController {
     private static final String EMPTY_POSITION_NAME_MESSAGE_KEY = "settings.positions.error.empty";
     private static final String TECHNICAL_ERROR_MESSAGE_KEY = "technical.error.message";
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionController.class);
+
+    private static final MediaType TEXT_PLAIN_UTF8 =
+            new MediaType("text", "plain", Charset.forName("UTF-8"));
+
     @Resource
     private PositionService positionService;
     @Resource
@@ -48,15 +55,24 @@ public class PositionController {
 
     @ExceptionHandler(DuplicateRecordException.class)
     public ResponseEntity handleDuplicateException(Locale locale, DuplicateRecordException ex) {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(TEXT_PLAIN_UTF8);
+
         return new ResponseEntity<>(messageSource.getMessage(DUPLICATE_POSITION_MESSAGE_KEY,
-                new Object[]{ex.getName()}, locale), HttpStatus.BAD_REQUEST);
+                new Object[]{ex.getName()}, locale), headers, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity handleException(Locale locale, Exception ex) {
         LOGGER.error("Error while saving position changes", ex);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(TEXT_PLAIN_UTF8);
+
         return new ResponseEntity<>(messageSource.getMessage(TECHNICAL_ERROR_MESSAGE_KEY,
-                null, locale), HttpStatus.BAD_REQUEST);
+                null, locale), headers, HttpStatus.BAD_REQUEST);
     }
 
 

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/PositionController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/PositionController.java
@@ -3,6 +3,7 @@ package com.epam.rft.atsy.web.controllers.rest;
 import com.epam.rft.atsy.service.PositionService;
 import com.epam.rft.atsy.service.domain.PositionDTO;
 import com.epam.rft.atsy.service.exception.DuplicateRecordException;
+import com.epam.rft.atsy.web.MediaTypes;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,9 +27,6 @@ public class PositionController {
     private static final String EMPTY_POSITION_NAME_MESSAGE_KEY = "settings.positions.error.empty";
     private static final String TECHNICAL_ERROR_MESSAGE_KEY = "technical.error.message";
     private static final Logger LOGGER = LoggerFactory.getLogger(PositionController.class);
-
-    private static final MediaType TEXT_PLAIN_UTF8 =
-            new MediaType("text", "plain", Charset.forName("UTF-8"));
 
     @Resource
     private PositionService positionService;
@@ -57,7 +55,7 @@ public class PositionController {
     public ResponseEntity handleDuplicateException(Locale locale, DuplicateRecordException ex) {
         HttpHeaders headers = new HttpHeaders();
 
-        headers.setContentType(TEXT_PLAIN_UTF8);
+        headers.setContentType(MediaTypes.TEXT_PLAIN_UTF8);
 
         return new ResponseEntity<>(messageSource.getMessage(DUPLICATE_POSITION_MESSAGE_KEY,
                 new Object[]{ex.getName()}, locale), headers, HttpStatus.BAD_REQUEST);
@@ -69,7 +67,7 @@ public class PositionController {
 
         HttpHeaders headers = new HttpHeaders();
 
-        headers.setContentType(TEXT_PLAIN_UTF8);
+        headers.setContentType(MediaTypes.TEXT_PLAIN_UTF8);
 
         return new ResponseEntity<>(messageSource.getMessage(TECHNICAL_ERROR_MESSAGE_KEY,
                 null, locale), headers, HttpStatus.BAD_REQUEST);

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/SingleCandidateController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/SingleCandidateController.java
@@ -3,6 +3,7 @@ package com.epam.rft.atsy.web.controllers.rest;
 import com.epam.rft.atsy.service.CandidateService;
 import com.epam.rft.atsy.service.domain.CandidateDTO;
 import com.epam.rft.atsy.service.exception.DuplicateRecordException;
+import com.epam.rft.atsy.web.MediaTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -29,9 +30,6 @@ public class SingleCandidateController {
     private static final String TECHNICAL_ERROR_MESSAGE_KEY = "technical.error.message";
     private static final Logger LOGGER = LoggerFactory.getLogger(SingleCandidateController.class);
 
-    private static final MediaType TEXT_PLAIN_UTF8 =
-            new MediaType("text", "plain", Charset.forName("UTF-8"));
-
     @Resource
     private CandidateService candidateService;
 
@@ -55,7 +53,7 @@ public class SingleCandidateController {
     public ResponseEntity handleDuplicateException(Locale locale, DuplicateRecordException ex) {
         HttpHeaders headers = new HttpHeaders();
 
-        headers.setContentType(TEXT_PLAIN_UTF8);
+        headers.setContentType(MediaTypes.TEXT_PLAIN_UTF8);
 
         return new ResponseEntity<>(messageSource.getMessage(DUPLICATE_CANDIDATE_ERROR_KEY,
                 new Object[]{ex.getName()}, locale), headers, HttpStatus.BAD_REQUEST);
@@ -67,7 +65,7 @@ public class SingleCandidateController {
 
         HttpHeaders headers = new HttpHeaders();
 
-        headers.setContentType(TEXT_PLAIN_UTF8);
+        headers.setContentType(MediaTypes.TEXT_PLAIN_UTF8);
 
         return new ResponseEntity<>(messageSource.getMessage(TECHNICAL_ERROR_MESSAGE_KEY,
                 null, locale), headers, HttpStatus.BAD_REQUEST);

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/SingleCandidateController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/SingleCandidateController.java
@@ -6,7 +6,9 @@ import com.epam.rft.atsy.service.exception.DuplicateRecordException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
 import javax.validation.Valid;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -25,6 +28,10 @@ public class SingleCandidateController {
     private static final String DUPLICATE_CANDIDATE_ERROR_KEY = "candidate.error.duplicate";
     private static final String TECHNICAL_ERROR_MESSAGE_KEY = "technical.error.message";
     private static final Logger LOGGER = LoggerFactory.getLogger(SingleCandidateController.class);
+
+    private static final MediaType TEXT_PLAIN_UTF8 =
+            new MediaType("text", "plain", Charset.forName("UTF-8"));
+
     @Resource
     private CandidateService candidateService;
 
@@ -46,15 +53,24 @@ public class SingleCandidateController {
 
     @ExceptionHandler(DuplicateRecordException.class)
     public ResponseEntity handleDuplicateException(Locale locale, DuplicateRecordException ex) {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(TEXT_PLAIN_UTF8);
+
         return new ResponseEntity<>(messageSource.getMessage(DUPLICATE_CANDIDATE_ERROR_KEY,
-                new Object[]{ex.getName()}, locale), HttpStatus.BAD_REQUEST);
+                new Object[]{ex.getName()}, locale), headers, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity handleException(Locale locale, Exception ex) {
         LOGGER.error("Error while saving position changes", ex);
+
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(TEXT_PLAIN_UTF8);
+
         return new ResponseEntity<>(messageSource.getMessage(TECHNICAL_ERROR_MESSAGE_KEY,
-                null, locale), HttpStatus.BAD_REQUEST);
+                null, locale), headers, HttpStatus.BAD_REQUEST);
     }
 
     private Map<String,String> parseValidationErrors(List<FieldError> fieldErrors, Locale locale){


### PR DESCRIPTION
Trello card
[https://trello.com/c/sH2e1njq](https://trello.com/c/sH2e1njq)

Fixed the issue described in the Trello card by setting the content type in the appropriate controllers' exception handler methods. 

_Note:_
When unifying the exception handling, it shouldn't be forgotten to set the character encoding in the response header.
