### PR TITLE
Fixed the Travis builds failing with Element no longer attached to DOM

### DIFF
--- a/web/src/test/java/com/epam/rft/atsy/cucumber/settings/channels/ChannelsStepDefs.java
+++ b/web/src/test/java/com/epam/rft/atsy/cucumber/settings/channels/ChannelsStepDefs.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static com.epam.rft.atsy.cucumber.util.DriverProvider.getDriver;
 import static com.epam.rft.atsy.cucumber.util.DriverProvider.waitForAjax;
+import static com.epam.rft.atsy.cucumber.util.DriverProvider.waitForPageLoadAfter;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,11 +43,12 @@ public class ChannelsStepDefs {
 
     @And("^the channels link is clicked$")
     public void the_positions_link_is_clicked() throws Throwable {
-        getDriver().findElement(By.id("channels_link")).click();
+        waitForPageLoadAfter(driver -> driver.findElement(By.id("channels_link")).click());
     }
 
     @And("^the channels screen appears$")
     public void the_positions_screen_appears() throws Throwable {
+        waitForAjax();
         WebDriverWait wait = new WebDriverWait(getDriver(), 5);
         wait.until(presenceOfElementLocated(By.id("channels")));
         assertThat(getDriver().findElement(By.id("settings")).isDisplayed(), is(true));

--- a/web/src/test/java/com/epam/rft/atsy/cucumber/welcome/WelcomeStepDefs.java
+++ b/web/src/test/java/com/epam/rft/atsy/cucumber/welcome/WelcomeStepDefs.java
@@ -64,8 +64,10 @@ public class WelcomeStepDefs {
 
     @And("the user changes the order field to (.*), (.*)")
     public void the_user_changes_the_order_field_to(String field, String order) {
-        WebElement sortElement = getDriver().findElement(By.cssSelector("#candidates_table div.fixed-table-header th[data-field=" + field + "] div.sortable"));
+        WebElement sortElement = getDriver().findElement(By.cssSelector("#candidates_table th[data-field=" + field + "] > div.sortable"));
+
         String currentOrderCss = sortElement.getAttribute("class");
+
         if (!(currentOrderCss).contains(order)) {
             sortElement.click();
             waitForAjax();

--- a/web/src/test/java/com/epam/rft/atsy/cucumber/welcome/WelcomeStepDefs.java
+++ b/web/src/test/java/com/epam/rft/atsy/cucumber/welcome/WelcomeStepDefs.java
@@ -62,9 +62,9 @@ public class WelcomeStepDefs {
         }
     }
 
-    @And("the user changes the order field to (.*), (.*)")
+    @When("the user changes the order field to (.*), (.*)")
     public void the_user_changes_the_order_field_to(String field, String order) {
-        WebElement sortElement = getDriver().findElement(By.cssSelector("#candidates_table th[data-field=" + field + "] > div.sortable"));
+        WebElement sortElement = getDriver().findElement(By.cssSelector("#candidates_table div.fixed-table-header th[data-field=" + field + "] div.sortable"));
 
         String currentOrderCss = sortElement.getAttribute("class");
 

--- a/web/src/test/resources/com/epam/rft/atsy/cucumber/Welcome.feature
+++ b/web/src/test/resources/com/epam/rft/atsy/cucumber/Welcome.feature
@@ -30,7 +30,7 @@ Feature: Welcome
       | Candidate C | candidate.c@atsy.com | +36107777777 | -         |
     When the user clicks on the Főoldal button
     Then the Candidates page appears
-    And the user changes the order field to <field>, <order>
+    When the user changes the order field to <field>, <order>
     And the list of candidates shown ordered by <field> as <order>
   Examples:
       | field     | order |

--- a/web/src/test/resources/com/epam/rft/atsy/cucumber/Welcome.feature
+++ b/web/src/test/resources/com/epam/rft/atsy/cucumber/Welcome.feature
@@ -29,8 +29,8 @@ Feature: Welcome
       | Candidate B | candidate.b@atsy.com | +36106666666 | -         |
       | Candidate C | candidate.c@atsy.com | +36107777777 | -         |
     When the user clicks on the Főoldal button
-    And the user changes the order field to <field>, <order>
     Then the Candidates page appears
+    And the user changes the order field to <field>, <order>
     And the list of candidates shown ordered by <field> as <order>
   Examples:
       | field     | order |


### PR DESCRIPTION
Trello card link:
[https://trello.com/c/2dXkzGTy](https://trello.com/c/2dXkzGTy)

The CSS selector was overly complicated, so it was simplified a bit, and swapped steps in the corresponding scenario so the web driver will wait for the table to load.
