### PR TITLE
Created REST ChannelControllerTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <org.springframework.security.version>4.0.3.RELEASE</org.springframework.security.version>
 
         <org.projectlombok.version>1.16.8</org.projectlombok.version>
+
+        <com.jayway.jsonpath.version>2.2.0</com.jayway.jsonpath.version>
     </properties>
 
     <modules>
@@ -449,6 +451,19 @@
                 <artifactId>lombok</artifactId>
                 <version>${org.projectlombok.version}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path</artifactId>
+                <version>${com.jayway.jsonpath.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.jayway.jsonpath</groupId>
+                <artifactId>json-path-assert</artifactId>
+                <version>${com.jayway.jsonpath.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -85,5 +85,13 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/web/src/main/java/com/epam/rft/atsy/web/MediaTypes.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/MediaTypes.java
@@ -8,6 +8,9 @@ public class MediaTypes {
   public static final MediaType TEXT_PLAIN_UTF8 =
       new MediaType("text", "plain", Charset.forName("UTF-8"));
 
+  public static final MediaType APPLICATION_JSON_UTF8 =
+      new MediaType("application", "json", Charset.forName("UTF-8"));
+
   private MediaTypes() {
     // Private to prevent instantiating.
   }

--- a/web/src/main/java/com/epam/rft/atsy/web/configuration/WebConfiguration.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/configuration/WebConfiguration.java
@@ -1,6 +1,7 @@
 package com.epam.rft.atsy.web.configuration;
 
 import com.epam.rft.atsy.service.configuration.ServiceConfiguration;
+import com.epam.rft.atsy.web.MediaTypes;
 import com.epam.rft.atsy.web.exceptionhandling.UncheckedExceptionResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
@@ -81,7 +82,13 @@ public class WebConfiguration extends WebMvcConfigurationSupport {
 
   @Bean
   public MappingJackson2JsonView mappingJackson2JsonView() {
-    return new MappingJackson2JsonView(objectMapper());
+    MappingJackson2JsonView jsonView = new MappingJackson2JsonView(objectMapper());
+
+    // Maintain consistency with the MappingJackson2HttpMessageConverter that automatically
+    // adds "charset=UTF-8" to the content-type.
+    jsonView.setContentType(MediaTypes.APPLICATION_JSON_UTF8.toString());
+
+    return jsonView;
   }
 
   @Override

--- a/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/ChannelController.java
+++ b/web/src/main/java/com/epam/rft/atsy/web/controllers/rest/ChannelController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Collection;
 import java.util.Locale;
 import javax.annotation.Resource;
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping(value = "/secure/channels")
@@ -36,7 +37,7 @@ public class ChannelController {
   }
 
   @RequestMapping(method = RequestMethod.POST)
-  public ResponseEntity<RestResponse> saveOrUpdate(@RequestBody ChannelDTO channelDTO,
+  public ResponseEntity<RestResponse> saveOrUpdate(@RequestBody @Valid ChannelDTO channelDTO,
                                                    BindingResult result, Locale locale) {
     if (!result.hasErrors()) {
       channelService.saveOrUpdate(channelDTO);

--- a/web/src/test/java/com/epam/rft/atsy/web/controllers/AbstractControllerTest.java
+++ b/web/src/test/java/com/epam/rft/atsy/web/controllers/AbstractControllerTest.java
@@ -1,16 +1,23 @@
 package com.epam.rft.atsy.web.controllers;
 
+import com.epam.rft.atsy.web.MediaTypes;
+import com.epam.rft.atsy.web.exceptionhandling.GlobalControllerExceptionHandler;
+import com.epam.rft.atsy.web.exceptionhandling.UncheckedExceptionResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
+import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
 public abstract class AbstractControllerTest {
   protected static final String VIEW_PREFIX = "/WEB-INF/pages/";
   protected static final String VIEW_SUFFIX = ".jsp";
 
   protected MockMvc mockMvc;
+
+  protected ObjectMapper objectMapper;
 
   protected ViewResolver viewResolver() {
     InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
@@ -23,9 +30,22 @@ public abstract class AbstractControllerTest {
 
   @Before
   public void setUp() {
+    objectMapper = new ObjectMapper();
+
     mockMvc =
-        MockMvcBuilders.standaloneSetup(controllersUnderTest()).setViewResolvers(viewResolver())
+        MockMvcBuilders.standaloneSetup(controllersUnderTest())
+            .setViewResolvers(viewResolver())
+            .setControllerAdvice(new GlobalControllerExceptionHandler())
+            .setHandlerExceptionResolvers(uncheckedExceptionResolver())
             .build();
+  }
+
+  protected UncheckedExceptionResolver uncheckedExceptionResolver() {
+    MappingJackson2JsonView jsonView = new MappingJackson2JsonView(objectMapper);
+
+    jsonView.setContentType(MediaTypes.APPLICATION_JSON_UTF8.toString());
+
+    return new UncheckedExceptionResolver(jsonView);
   }
 
   protected abstract Object[] controllersUnderTest();

--- a/web/src/test/java/com/epam/rft/atsy/web/controllers/AbstractControllerTest.java
+++ b/web/src/test/java/com/epam/rft/atsy/web/controllers/AbstractControllerTest.java
@@ -19,6 +19,18 @@ public abstract class AbstractControllerTest {
 
   protected ObjectMapper objectMapper;
 
+  @Before
+  public void setUp() {
+    objectMapper = new ObjectMapper();
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controllersUnderTest())
+            .setViewResolvers(viewResolver())
+            .setControllerAdvice(controllerAdvice())
+            .setHandlerExceptionResolvers(uncheckedExceptionResolver())
+            .build();
+  }
+
   protected ViewResolver viewResolver() {
     InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
 
@@ -28,24 +40,16 @@ public abstract class AbstractControllerTest {
     return viewResolver;
   }
 
-  @Before
-  public void setUp() {
-    objectMapper = new ObjectMapper();
-
-    mockMvc =
-        MockMvcBuilders.standaloneSetup(controllersUnderTest())
-            .setViewResolvers(viewResolver())
-            .setControllerAdvice(new GlobalControllerExceptionHandler())
-            .setHandlerExceptionResolvers(uncheckedExceptionResolver())
-            .build();
-  }
-
   protected UncheckedExceptionResolver uncheckedExceptionResolver() {
     MappingJackson2JsonView jsonView = new MappingJackson2JsonView(objectMapper);
 
     jsonView.setContentType(MediaTypes.APPLICATION_JSON_UTF8.toString());
 
     return new UncheckedExceptionResolver(jsonView);
+  }
+
+  protected Object[] controllerAdvice() {
+    return new Object[]{new GlobalControllerExceptionHandler()};
   }
 
   protected abstract Object[] controllersUnderTest();

--- a/web/src/test/java/com/epam/rft/atsy/web/controllers/rest/ChannelControllerTest.java
+++ b/web/src/test/java/com/epam/rft/atsy/web/controllers/rest/ChannelControllerTest.java
@@ -1,9 +1,17 @@
 package com.epam.rft.atsy.web.controllers.rest;
 
 import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,6 +20,8 @@ import com.epam.rft.atsy.service.ChannelService;
 import com.epam.rft.atsy.service.domain.ChannelDTO;
 import com.epam.rft.atsy.web.MediaTypes;
 import com.epam.rft.atsy.web.controllers.AbstractControllerTest;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +32,7 @@ import org.springframework.context.MessageSource;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ChannelControllerTest extends AbstractControllerTest {
@@ -30,6 +41,12 @@ public class ChannelControllerTest extends AbstractControllerTest {
   private static final Long CHANNEL_ID = 1L;
 
   private static final String CHANNEL_NAME = "Channel";
+
+  private static final String REQUEST_BODY_IS_MISSING_MESSAGE = "Required request body is missing";
+
+  private static final String EMPTY_POSITION_NAME_MESSAGE_KEY = "settings.channels.error.empty";
+
+  private static final String VALIDATION_ERROR_MESSAGE = "Validation error";
 
   @Mock
   private ChannelService channelService;
@@ -40,11 +57,19 @@ public class ChannelControllerTest extends AbstractControllerTest {
   @InjectMocks
   private ChannelController channelController;
 
-  private ChannelDTO dummyDto;
+  private ChannelDTO persistedDto;
+
+  private ChannelDTO emptyPostedDto;
+
+  private ChannelDTO correctPostedDto;
 
   @Before
   public void setUpTestData() {
-    dummyDto = ChannelDTO.builder().id(CHANNEL_ID).name(CHANNEL_NAME).build();
+    persistedDto = ChannelDTO.builder().id(CHANNEL_ID).name(CHANNEL_NAME).build();
+
+    emptyPostedDto = ChannelDTO.builder().name(StringUtils.EMPTY).build();
+
+    correctPostedDto = ChannelDTO.builder().name(CHANNEL_NAME).build();
   }
 
   @Override
@@ -53,7 +78,7 @@ public class ChannelControllerTest extends AbstractControllerTest {
   }
 
   @Test
-  public void getChannelsShouldReturnEmptyJsonArrayWhenThereAreNoChannels() throws Exception {
+  public void getChannelsShouldRespondWithEmptyJsonArrayWhenThereAreNoChannels() throws Exception {
     given(channelService.getAllChannels()).willReturn(Collections.emptyList());
 
     mockMvc.perform(get(REQUEST_URL))
@@ -61,11 +86,14 @@ public class ChannelControllerTest extends AbstractControllerTest {
         .andExpect(content().contentType(MediaTypes.APPLICATION_JSON_UTF8))
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$").isEmpty());
+
+    then(channelService).should().getAllChannels();
   }
 
   @Test
-  public void getChannelsShouldReturnJsonWithOneChannelWhenThereIsOneChannel() throws Exception {
-    List<ChannelDTO> channels = Collections.singletonList(dummyDto);
+  public void getChannelsShouldRespondWithJsonWithOneChannelWhenThereIsOneChannel()
+      throws Exception {
+    List<ChannelDTO> channels = Collections.singletonList(persistedDto);
 
     given(channelService.getAllChannels()).willReturn(channels);
 
@@ -76,11 +104,14 @@ public class ChannelControllerTest extends AbstractControllerTest {
         .andExpect(jsonPath("$", hasSize(1)))
         .andExpect(jsonPath("$[0].id", is(CHANNEL_ID.intValue())))
         .andExpect(jsonPath("$[0].name", is(CHANNEL_NAME)));
+
+    then(channelService).should().getAllChannels();
   }
 
   @Test
-  public void getChannelsShouldReturnJsonWithThreeChannelsWhenThereAreThreeChannels() throws Exception {
-    List<ChannelDTO> channels = Collections.nCopies(3, dummyDto);
+  public void getChannelsShouldRespondWithJsonWithThreeChannelsWhenThereAreThreeChannels()
+      throws Exception {
+    List<ChannelDTO> channels = Collections.nCopies(3, persistedDto);
 
     given(channelService.getAllChannels()).willReturn(channels);
 
@@ -95,7 +126,60 @@ public class ChannelControllerTest extends AbstractControllerTest {
         .andExpect(jsonPath("$[1].name", is(CHANNEL_NAME)))
         .andExpect(jsonPath("$[2].id", is(CHANNEL_ID.intValue())))
         .andExpect(jsonPath("$[2].name", is(CHANNEL_NAME)));
+
+    then(channelService).should().getAllChannels();
   }
 
+  @Test
+  public void saveOrUpdateShouldRespondWithErrorResponseWhenRequestBodyIsMissing()
+      throws Exception {
+    mockMvc.perform(post(REQUEST_URL)
+        .contentType(MediaTypes.APPLICATION_JSON_UTF8)
+        .accept(MediaTypes.APPLICATION_JSON_UTF8))
+        .andExpect(status().isInternalServerError())
+        .andExpect(content().contentType(MediaTypes.APPLICATION_JSON_UTF8))
+        .andExpect(jsonPath("$.errorMessage").isNotEmpty())
+        .andExpect(jsonPath("$.errorMessage", containsString(REQUEST_BODY_IS_MISSING_MESSAGE)))
+        .andExpect(jsonPath("$.fields").isEmpty());
+  }
 
+  @Test
+  public void saveOrUpdateShouldRespondWithValidationErrorWhenNameIsTheEmptyString()
+      throws Exception {
+    // the value of the id field in the DTO is null so tell the objectMapper
+    // not to include null fields in the JSON
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    given(
+        messageSource.getMessage(eq(EMPTY_POSITION_NAME_MESSAGE_KEY), isNull(Object[].class),
+            any(Locale.class)))
+        .willReturn(VALIDATION_ERROR_MESSAGE);
+
+    mockMvc.perform(post(REQUEST_URL)
+        .contentType(MediaTypes.APPLICATION_JSON_UTF8)
+        .accept(MediaTypes.APPLICATION_JSON_UTF8)
+        .content(objectMapper.writeValueAsBytes(emptyPostedDto)))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.errorMessage").isNotEmpty())
+        .andExpect(jsonPath("$.errorMessage", equalTo(VALIDATION_ERROR_MESSAGE)))
+        .andExpect(jsonPath("$.fields").isEmpty());
+
+    verifyZeroInteractions(channelService);
+  }
+
+  @Test
+  public void saveOrUpdateShouldRespondWithNoErrorResponseWhenThePostedJsonIsCorrect()
+      throws Exception {
+    mockMvc.perform(post(REQUEST_URL)
+        .contentType(MediaTypes.APPLICATION_JSON_UTF8)
+        .accept(MediaTypes.APPLICATION_JSON_UTF8)
+        .content(objectMapper.writeValueAsBytes(correctPostedDto)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.errorMessage").isEmpty())
+        .andExpect(jsonPath("$.fields").isEmpty());
+
+    then(channelService).should().saveOrUpdate(correctPostedDto);
+
+    verifyZeroInteractions(messageSource);
+  }
 }

--- a/web/src/test/java/com/epam/rft/atsy/web/controllers/rest/ChannelControllerTest.java
+++ b/web/src/test/java/com/epam/rft/atsy/web/controllers/rest/ChannelControllerTest.java
@@ -1,0 +1,101 @@
+package com.epam.rft.atsy.web.controllers.rest;
+
+import static com.jayway.jsonassert.impl.matcher.IsCollectionWithSize.hasSize;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epam.rft.atsy.service.ChannelService;
+import com.epam.rft.atsy.service.domain.ChannelDTO;
+import com.epam.rft.atsy.web.MediaTypes;
+import com.epam.rft.atsy.web.controllers.AbstractControllerTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.context.MessageSource;
+
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChannelControllerTest extends AbstractControllerTest {
+  private static final String REQUEST_URL = "/secure/channels";
+
+  private static final Long CHANNEL_ID = 1L;
+
+  private static final String CHANNEL_NAME = "Channel";
+
+  @Mock
+  private ChannelService channelService;
+
+  @Mock
+  private MessageSource messageSource;
+
+  @InjectMocks
+  private ChannelController channelController;
+
+  private ChannelDTO dummyDto;
+
+  @Before
+  public void setUpTestData() {
+    dummyDto = ChannelDTO.builder().id(CHANNEL_ID).name(CHANNEL_NAME).build();
+  }
+
+  @Override
+  protected Object[] controllersUnderTest() {
+    return new Object[]{channelController};
+  }
+
+  @Test
+  public void getChannelsShouldReturnEmptyJsonArrayWhenThereAreNoChannels() throws Exception {
+    given(channelService.getAllChannels()).willReturn(Collections.emptyList());
+
+    mockMvc.perform(get(REQUEST_URL))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.APPLICATION_JSON_UTF8))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  public void getChannelsShouldReturnJsonWithOneChannelWhenThereIsOneChannel() throws Exception {
+    List<ChannelDTO> channels = Collections.singletonList(dummyDto);
+
+    given(channelService.getAllChannels()).willReturn(channels);
+
+    mockMvc.perform(get(REQUEST_URL))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.APPLICATION_JSON_UTF8))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].id", is(CHANNEL_ID.intValue())))
+        .andExpect(jsonPath("$[0].name", is(CHANNEL_NAME)));
+  }
+
+  @Test
+  public void getChannelsShouldReturnJsonWithThreeChannelsWhenThereAreThreeChannels() throws Exception {
+    List<ChannelDTO> channels = Collections.nCopies(3, dummyDto);
+
+    given(channelService.getAllChannels()).willReturn(channels);
+
+    mockMvc.perform(get(REQUEST_URL))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaTypes.APPLICATION_JSON_UTF8))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(3)))
+        .andExpect(jsonPath("$[0].id", is(CHANNEL_ID.intValue())))
+        .andExpect(jsonPath("$[0].name", is(CHANNEL_NAME)))
+        .andExpect(jsonPath("$[1].id", is(CHANNEL_ID.intValue())))
+        .andExpect(jsonPath("$[1].name", is(CHANNEL_NAME)))
+        .andExpect(jsonPath("$[2].id", is(CHANNEL_ID.intValue())))
+        .andExpect(jsonPath("$[2].name", is(CHANNEL_NAME)));
+  }
+
+
+}


### PR DESCRIPTION
Trello card link:
[https://trello.com/c/MgDVylBC](https://trello.com/c/MgDVylBC)

**Note:**
I've added a small modification to the WebConfiguration. REST controllers return responses with the header field `Content-Type` set to `application/json;charset=UTF-8`.
Before the fix the `UncheckedExceptionResolver` only returned `application/json` that made testing a bit awkward and the application inconsistent, therefore I changed the configuration. This is mostly an issue when testing.
