### PR TITLE
EMail address should be clickable instead of envelop icon

### DIFF
--- a/web/src/main/webapp/WEB-INF/pages/candidate_create.jsp
+++ b/web/src/main/webapp/WEB-INF/pages/candidate_create.jsp
@@ -115,9 +115,8 @@
                                 <span id="email-errors" class="help-block with-errors"></span>
 
                                 <p class="showValue form-control-static">
-                                    <a href="mailto:${candidate.email}"><span class="glyphicon glyphicon-envelope"
-                                                                              title="E-mail küldése"></span></a>
-                                        <c:out value = "${candidate.email}"/></p>
+                                  <a href="mailto:${candidate.email}"><c:out value = "${candidate.email}"/></a>
+                                </p>
                             </div>
 
                         </div>


### PR DESCRIPTION
https://trello.com/c/L3tLOfL9/101-email-address-should-be-clickable-on-the-candidate-details-page
